### PR TITLE
Debug option: Don't send email or check phone

### DIFF
--- a/src/webapp/email-service.js
+++ b/src/webapp/email-service.js
@@ -10,7 +10,7 @@ const sendEmail = async ({ to, subject, html }) => {
   console.log('Sent email', { to, subject, html });
   // return mg.messages.create(MAILGUN_MESSAGING_DOMAIN, data);
   if (DEBUG_FAKE_SERVICES=='true' || DEBUG_FAKE_SERVICES=='True') {
-    console.log('DEBUG_FAKE_SERVICES Flag is used. Mot sending email');
+    console.log('DEBUG_FAKE_SERVICES Flag is used. Not sending email. Displaying the link on the console instead.');
     return;
   }
 

--- a/src/webapp/email-service.js
+++ b/src/webapp/email-service.js
@@ -3,12 +3,17 @@ const base64 = require('base-64');
 const FormData = require('form-data');
 
 const {
-  MAILGUN_API_KEY, MAILGUN_MESSAGING_DOMAIN, MAILGUN_SENDER, MAILGUN_SERVICE_DOMAIN
+  MAILGUN_API_KEY, MAILGUN_MESSAGING_DOMAIN, MAILGUN_SENDER, MAILGUN_SERVICE_DOMAIN, DEBUG_FAKE_SERVICES
 } = process.env;
 
 const sendEmail = async ({ to, subject, html }) => {
   console.log('Sent email', { to, subject, html });
   // return mg.messages.create(MAILGUN_MESSAGING_DOMAIN, data);
+  if (DEBUG_FAKE_SERVICES=='true' || DEBUG_FAKE_SERVICES=='True') {
+    console.log('DEBUG_FAKE_SERVICES Flag is used. Mot sending email');
+    return;
+  }
+
   const formData = new FormData();
   formData.append('from', MAILGUN_SENDER);
   formData.append('to', to);

--- a/src/webapp/index.js
+++ b/src/webapp/index.js
@@ -51,7 +51,8 @@ app.use(memberMountPoint, member);
 
 app.get('/', (req, res) => {
   res.render('index', {
-    success: !!req.query.success
+    success: !!req.query.success,
+    debugEmailUrl: req.query.debug_email_url
   });
 });
 

--- a/src/webapp/member.js
+++ b/src/webapp/member.js
@@ -9,7 +9,7 @@ const mustache = require('mustache');
 
 const sendEmail = require('./email-service');
 
-const {PUBLIC_ADDRESS, REVOKE_EMAIL_RECIPIENT} = process.env;
+const {PUBLIC_ADDRESS, REVOKE_EMAIL_RECIPIENT, DEBUG_FAKE_SERVICES} = process.env;
 const {emailVerification, phoneVerification} = require('./verification-schemes/');
 const {member: Member} = require('./models/');
 const handleAsync = require('./handle-async');
@@ -30,6 +30,12 @@ router.post('/sign-up', handleAsync(async (req, res) => {
   publicUrl.pathname = path.join(publicUrl.pathname, req.baseUrl, 'verify');
 
   emailVerification.challenge(publicUrl.href, member);
+
+  if (DEBUG_FAKE_SERVICES=='true' || DEBUG_FAKE_SERVICES=='True') {
+    const emailUrl = escape(emailVerification.url(publicUrl.href, member));
+    console.log('DEBUG_FAKE_SERVICES Flag is used. Displaying url: ' + emailUrl);
+    res.redirect('/?success=1&debug_email_url=' + emailUrl);
+  }
 
   res.redirect('/?success=1');
 }));

--- a/src/webapp/verification-schemes/email.js
+++ b/src/webapp/verification-schemes/email.js
@@ -28,10 +28,15 @@ const messageTemplate = fs.readFileSync(
 
 exports.name = NAME;
 
-exports.challenge = async (responseUrl, member) => {
+exports.url = (responseUrl, member) => {
   const url = new URL(responseUrl);
   url.searchParams.set('name', NAME);
   url.searchParams.set('value', member.emailChallenge);
+  return url;
+};
+
+exports.challenge = async (responseUrl, member) => {
+  const url = exports.url(responseUrl, member)
   const message = mustache.render(messageTemplate, {url: url.href});
   const firstNewline = message.indexOf('\n');
   const subject = message.substr(0, firstNewline);

--- a/src/webapp/verification-schemes/phone.js
+++ b/src/webapp/verification-schemes/phone.js
@@ -26,7 +26,7 @@ module.exports = {
   
   challenge: async member => {
     if (DEBUG_FAKE_SERVICES=='true' || DEBUG_FAKE_SERVICES=='True') {
-      console.log('DEBUG_FAKE_SERVICES Flag is used. Mot chalenging sms to phone #', member.phone);
+      console.log('DEBUG_FAKE_SERVICES Flag is used. Not chalenging sms to phone #', member.phone);
     } else {
       let formData = new FormData();
       formData.append('To', member.phone);
@@ -50,7 +50,7 @@ module.exports = {
 
   verify: async (member, smsCode) => {
     if (DEBUG_FAKE_SERVICES=='true' || DEBUG_FAKE_SERVICES=='True') {
-      console.log('DEBUG_FAKE_SERVICES Flag is used. Mot verifying sms to phone #', member.phone);
+      console.log('DEBUG_FAKE_SERVICES Flag is used. Not verifying sms to phone #', member.phone);
     } else {
       let formData = new FormData();
       formData.append('To', member.phone);

--- a/src/webapp/verification-schemes/phone.js
+++ b/src/webapp/verification-schemes/phone.js
@@ -19,49 +19,57 @@ const PHONE_CHALLENGE_RETRY_PERIOD = 24;
  */
 const PHONE_CHALLENGE_QUIT_DELAY = 72;
 
-const {TWILIO_SERVICE_DOMAIN, TWILIO_SERVICE_ID, TWILIO_SID, TWILIO_AUTH_TOKEN} = process.env;
+const {TWILIO_SERVICE_DOMAIN, TWILIO_SERVICE_ID, TWILIO_SID, TWILIO_AUTH_TOKEN, DEBUG_FAKE_SERVICES} = process.env;
 
 module.exports = {
   name: 'phone',
   
   challenge: async member => {
-    let formData = new FormData();
-    formData.append('To', member.phone);
-    formData.append('Channel', 'sms');
+    if (DEBUG_FAKE_SERVICES=='true' || DEBUG_FAKE_SERVICES=='True') {
+      console.log('DEBUG_FAKE_SERVICES Flag is used. Mot chalenging sms to phone #', member.phone);
+    } else {
+      let formData = new FormData();
+      formData.append('To', member.phone);
+      formData.append('Channel', 'sms');
 
-    await fetch(
-      `${TWILIO_SERVICE_DOMAIN}/v2/Services/${TWILIO_SERVICE_ID}/Verifications`,
-      { 
-        method: 'POST', 
-        body: formData, 
-        headers: {
-          Authorization: `Basic ${base64.encode(`${TWILIO_SID}:${TWILIO_AUTH_TOKEN}`)}`
-        }
-      },
-    );
+      await fetch(
+        `${TWILIO_SERVICE_DOMAIN}/v2/Services/${TWILIO_SERVICE_ID}/Verifications`,
+        { 
+          method: 'POST', 
+          body: formData, 
+          headers: {
+            Authorization: `Basic ${base64.encode(`${TWILIO_SID}:${TWILIO_AUTH_TOKEN}`)}`
+          }
+        },
+      );
 
-    member.phoneChallengeAt = DateTime.local().toISO();
-    await member.save();
+      member.phoneChallengeAt = DateTime.local().toISO();
+      await member.save();
+    }
   },
 
   verify: async (member, smsCode) => {
-    let formData = new FormData();
-    formData.append('To', member.phone);
-    formData.append('Code', smsCode);
+    if (DEBUG_FAKE_SERVICES=='true' || DEBUG_FAKE_SERVICES=='True') {
+      console.log('DEBUG_FAKE_SERVICES Flag is used. Mot verifying sms to phone #', member.phone);
+    } else {
+      let formData = new FormData();
+      formData.append('To', member.phone);
+      formData.append('Code', smsCode);
 
-    const rawResponse = await fetch(
-      `${TWILIO_SERVICE_DOMAIN}/v2/Services/${TWILIO_SERVICE_ID}/VerificationCheck`,
-      { 
-        method: 'POST', 
-        body: formData, 
-        headers: {
-          Authorization: `Basic ${base64.encode(`${TWILIO_SID}:${TWILIO_AUTH_TOKEN}`)}`
-        }
-      },
-    );
-    const response = await rawResponse.json();
-    if (!(response && response.status === 'approved')) {
-      return false;
+      const rawResponse = await fetch(
+        `${TWILIO_SERVICE_DOMAIN}/v2/Services/${TWILIO_SERVICE_ID}/VerificationCheck`,
+        { 
+          method: 'POST', 
+          body: formData, 
+          headers: {
+            Authorization: `Basic ${base64.encode(`${TWILIO_SID}:${TWILIO_AUTH_TOKEN}`)}`
+          }
+        },
+      );
+      const response = await rawResponse.json();
+      if (!(response && response.status === 'approved')) {
+        return false;
+      }
     }
 
     member.phoneVerified = true;

--- a/src/webapp/views/index.mustache
+++ b/src/webapp/views/index.mustache
@@ -18,6 +18,9 @@
     <p> If you have any trouble with this process, let us know at datarightsstudy@cr.org.</p>
 </div>
 {{/success}}
+{{#debugEmailUrl}}
+      <h3 style="color:red;">Debug: link in email is <a href="{{debugEmailUrl}}">{{debugEmailUrl}}</a>.</h3>
+{{/debugEmailUrl}}
 {{^success}}
 <div class="column">
     <h1>Volunteer to test the Authorized Agent feature of California's new privacy law</h1>


### PR DESCRIPTION
I tried to add an option in env `DEBUG_FAKE_SERVICES=true` for easier debugging. Instead of sending email it displays the link in the email, and instead of sending SMS it accept any code.

Note:
* I checked it only with the flag, I don't have email/SMS service to test it otherwise
* package-lock.json changed automatically. 
