### PR TITLE
show a message if ENABLE_STUDY_FULL=(1/True/true) in process environment

### DIFF
--- a/src/webapp/index.js
+++ b/src/webapp/index.js
@@ -80,6 +80,10 @@ app.get('/', (req, res) => {
     });
 });
 
+app.get('/faq', (req, res) => {
+    return res.render('faq');
+});
+
 app.use((err, req, res, next) => {
     console.log('res.headersSent:', res.headersSent);
     if (res.headersSent) {

--- a/src/webapp/index.js
+++ b/src/webapp/index.js
@@ -13,6 +13,8 @@ const member = require('./member');
 const {remindUnverified} = require('./verification-schemes/');
 const memberMountPoint = '/member';
 
+const {studyFullCheck} = require('./study-full');
+
 const challengeResponseUrl = (() => {
     const url = new URL(PUBLIC_ADDRESS);
     url.pathname = path.join(url.pathname, memberMountPoint, 'verify');
@@ -70,9 +72,11 @@ app.use(express.urlencoded({ extended: true }));
 app.use(memberMountPoint, member);
 
 app.get('/', (req, res) => {
-    res.render('index', {
-        success: !!req.query.success,
-        debugEmailUrl: req.query.debug_email_url
+    studyFullCheck(req, res, () => {
+        return res.render('index', {
+            success: !!req.query.success,
+            debugEmailUrl: req.query.debug_email_url
+        });
     });
 });
 

--- a/src/webapp/member.js
+++ b/src/webapp/member.js
@@ -13,70 +13,73 @@ const {PUBLIC_ADDRESS, REVOKE_EMAIL_RECIPIENT, DEBUG_FAKE_SERVICES} = process.en
 const {emailVerification, phoneVerification} = require('./verification-schemes/');
 const {member: Member} = require('./models/');
 const handleAsync = require('./handle-async');
+const {studyFullCheck} = require('./study-full');
 
 const router = Router();
 
 router.post('/sign-up', handleAsync(async (req, res) => {
-  const member = await Member.create({
-    firstName: req.body['first-name'],
-    lastName: req.body['last-name'],
-    streetAddress: req.body['address-street'],
-    city: req.body['address-city'],
-    zipcode: req.body['address-zipcode'],
-    email: req.body.email,
-    phone: phone(req.body.phone)[0],
+  studyFullCheck(req, res, () => {
+    const member = await Member.create({
+      firstName: req.body['first-name'],
+      lastName: req.body['last-name'],
+      streetAddress: req.body['address-street'],
+      city: req.body['address-city'],
+      zipcode: req.body['address-zipcode'],
+      email: req.body.email,
+      phone: phone(req.body.phone)[0],
+    });
+    const publicUrl = new URL(PUBLIC_ADDRESS);
+    publicUrl.pathname = path.join(publicUrl.pathname, req.baseUrl, 'verify');
+
+    emailVerification.challenge(publicUrl.href, member);
+
+    if (DEBUG_FAKE_SERVICES=='true' || DEBUG_FAKE_SERVICES=='True') {
+      const emailUrl = escape(emailVerification.url(publicUrl.href, member));
+      console.log('DEBUG_FAKE_SERVICES Flag is used. Displaying url: ' + emailUrl);
+      res.redirect('/?success=1&debug_email_url=' + emailUrl);
+    }
+
+    res.redirect('/?success=1');
   });
-  const publicUrl = new URL(PUBLIC_ADDRESS);
-  publicUrl.pathname = path.join(publicUrl.pathname, req.baseUrl, 'verify');
-
-  emailVerification.challenge(publicUrl.href, member);
-
-  if (DEBUG_FAKE_SERVICES=='true' || DEBUG_FAKE_SERVICES=='True') {
-    const emailUrl = escape(emailVerification.url(publicUrl.href, member));
-    console.log('DEBUG_FAKE_SERVICES Flag is used. Displaying url: ' + emailUrl);
-    res.redirect('/?success=1&debug_email_url=' + emailUrl);
-  }
-
-  res.redirect('/?success=1');
 }));
 
 router.get('/verify', handleAsync(async (req, res) => {
-  const member = await Member.findOne({
-    where: {
-      emailChallenge: req.query.value
+    const member = await Member.findOne({
+      where: {
+        emailChallenge: req.query.value
+      }
+    });
+
+    if (!await emailVerification.verify(req.query.value)) {
+      throw new Error('Verification failed.');
     }
-  });
 
-  if (!await emailVerification.verify(req.query.value)) {
-    throw new Error('Verification failed.');
-  }
+    phoneVerification.challenge(member);
 
-  phoneVerification.challenge(member);
-
-  res.render('member/verify');
+    res.render('member/verify');
 }));
 
 router.post('/verify-phone-code', handleAsync(async (req, res) => {
-  const member = await Member.findOne({
-    where: {
-      emailChallenge: req.query.emailChallenge
+    const member = await Member.findOne({
+      where: {
+        emailChallenge: req.query.emailChallenge
+      }
+    });
+
+    if (!await phoneVerification.verify(member, req.query.smsCode)) {
+      throw new Error('Verification failed.');
     }
-  });
 
-  if (!await phoneVerification.verify(member, req.query.smsCode)) {
-    throw new Error('Verification failed.');
-  }
+    const messageTemplate = fs.readFileSync(
+      __dirname + '/views/member/authorization-email.mustache', 'utf-8'
+    );
+    const message = mustache.render(messageTemplate);
+    const firstNewline = message.indexOf('\n');
+    const subject = message.substr(0, firstNewline);
+    const html = message.substr(firstNewline);
+    await sendEmail({ to: member.email, subject, html });
 
-  const messageTemplate = fs.readFileSync(
-    __dirname + '/views/member/authorization-email.mustache', 'utf-8'
-  );
-  const message = mustache.render(messageTemplate);
-  const firstNewline = message.indexOf('\n');
-  const subject = message.substr(0, firstNewline);
-  const html = message.substr(firstNewline);
-  await sendEmail({ to: member.email, subject, html });
-
-  res.json({ success: true });
+    res.json({ success: true });
 }));
 
 router.post('/revoke-authorization', handleAsync(async (req, res) => {
@@ -102,5 +105,5 @@ router.post('/revoke-authorization', handleAsync(async (req, res) => {
   res.json({ success: true });
 }));
 
- 
+
 module.exports = router;

--- a/src/webapp/member.js
+++ b/src/webapp/member.js
@@ -18,7 +18,7 @@ const {studyFullCheck} = require('./study-full');
 const router = Router();
 
 router.post('/sign-up', handleAsync(async (req, res) => {
-  studyFullCheck(req, res, () => {
+  studyFullCheck(req, res, async () => {
     const member = await Member.create({
       firstName: req.body['first-name'],
       lastName: req.body['last-name'],

--- a/src/webapp/member.js
+++ b/src/webapp/member.js
@@ -44,42 +44,42 @@ router.post('/sign-up', handleAsync(async (req, res) => {
 }));
 
 router.get('/verify', handleAsync(async (req, res) => {
-    const member = await Member.findOne({
-      where: {
-        emailChallenge: req.query.value
-      }
-    });
-
-    if (!await emailVerification.verify(req.query.value)) {
-      throw new Error('Verification failed.');
+  const member = await Member.findOne({
+    where: {
+      emailChallenge: req.query.value
     }
+  });
 
-    phoneVerification.challenge(member);
+  if (!await emailVerification.verify(req.query.value)) {
+    throw new Error('Verification failed.');
+  }
 
-    res.render('member/verify');
+  phoneVerification.challenge(member);
+
+  res.render('member/verify');
 }));
 
 router.post('/verify-phone-code', handleAsync(async (req, res) => {
-    const member = await Member.findOne({
-      where: {
-        emailChallenge: req.query.emailChallenge
-      }
-    });
-
-    if (!await phoneVerification.verify(member, req.query.smsCode)) {
-      throw new Error('Verification failed.');
+  const member = await Member.findOne({
+    where: {
+      emailChallenge: req.query.emailChallenge
     }
+  });
 
-    const messageTemplate = fs.readFileSync(
-      __dirname + '/views/member/authorization-email.mustache', 'utf-8'
-    );
-    const message = mustache.render(messageTemplate);
-    const firstNewline = message.indexOf('\n');
-    const subject = message.substr(0, firstNewline);
-    const html = message.substr(firstNewline);
-    await sendEmail({ to: member.email, subject, html });
+  if (!await phoneVerification.verify(member, req.query.smsCode)) {
+    throw new Error('Verification failed.');
+  }
 
-    res.json({ success: true });
+  const messageTemplate = fs.readFileSync(
+    __dirname + '/views/member/authorization-email.mustache', 'utf-8'
+  );
+  const message = mustache.render(messageTemplate);
+  const firstNewline = message.indexOf('\n');
+  const subject = message.substr(0, firstNewline);
+  const html = message.substr(firstNewline);
+  await sendEmail({ to: member.email, subject, html });
+
+  res.json({ success: true });
 }));
 
 router.post('/revoke-authorization', handleAsync(async (req, res) => {

--- a/src/webapp/study-full.js
+++ b/src/webapp/study-full.js
@@ -3,13 +3,15 @@
 const {ENABLE_STUDY_FULL} = process.env;
 
 const studyFullCheck = (req, res, openCb) => {
-    if (ENABLE_STUDY_FULL == 'true' ||
-        ENABLE_STUDY_FULL == 'True' ||
-        ENABLE_STUDY_FULL == '1') {
-        res.render('full');
-    } else {
-        openCb();
-    }
+  if (ENABLE_STUDY_FULL == undefined) {
+    return openCb();
+  } else if (ENABLE_STUDY_FULL.toLowerCase() == 'true') {
+    return res.render('full');
+  } else if (ENABLE_STUDY_FULL == '1') {
+    return res.render('full');
+  } else {
+    return openCb();
+  }
 };
 
 module.exports = { studyFullCheck };

--- a/src/webapp/study-full.js
+++ b/src/webapp/study-full.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const {ENABLE_STUDY_FULL} = process.env;
+
+const studyFullCheck = (req, res, openCb) => {
+    if (ENABLE_STUDY_FULL == 'true' ||
+        ENABLE_STUDY_FULL == 'True' ||
+        ENABLE_STUDY_FULL == '1') {
+        res.render('full');
+    } else {
+        openCb();
+    }
+};
+
+module.exports = { studyFullCheck };

--- a/src/webapp/views/faq.mustache
+++ b/src/webapp/views/faq.mustache
@@ -1,0 +1,68 @@
+{{>common-top}}
+
+<h1>FAQ - Authorized Agent research</h1>
+
+<div class="column">
+    <h2>1. Can I revoke my authorization during or after the study?</h2>
+	<p>Yes, you can revoke authorization at any point. Please send us a note to <a href="mailto:datarightsstudy@cr.org">datarightsstudy@cr.org</a> and we will send you a personalized link to cease our authorized representation of you. 
+
+	After the study, the authorization will technically continue unless you explicitly revoke it. When we finish our research analysis, we will send a note with a short web form that allows you to revoke the authorization. 
+
+	That said, even if you don't revoke the authorization, after this study we will never take any further action as an Authorized Agent on your behalf without your explicit permission.  
+
+	If you are one of the small group that granted CR Power of Attorney with extra signatures (see FAQ #8, you should know who you are), we will provide you with a more extensive written form to fully revoke that authorization and send copies of it to the third parties to which it was originally sent. Please reach out to <a href="mailto:datarightsstudy@cr.org">datarightsstudy@cr.org</a> with any questions.</p>
+	
+	
+	<h2>2. How might companies ask me to confirm my identity?
+</h2>
+	<p>The process will differ from company to company and may depend on whether you already have a password-protected account with that company. In general, a company should ask you to provide identifying data that matches the information the company already maintains. 
+
+	Some will ask you to verify your identity within 24 hours by clicking on an email link. Depending on the sensitivity and value of the data a company has for you, the company might give you up to 7 days to send a copy of your government-issued ID. <b>If companies ask you for your Social Security Number, driver’s license number, health insurance information or any piece of information they shouldn’t already have access to please consider emailing</b> <a href="mailto:datarightsstudy@cr.org">datarightsstudy@cr.org</a>. For example, a pet store should probably not ask for a driver’s license number to verify your identity, but your car insurance company might. It may be inappropriate (or even unlawful) for companies to ask for this sensitive type of data and we’ll want to make note in our report to the Attorney General’s Office. 
+
+	Consumer Reports confirms your identity via email and phone when you sign up for this study. It is possible that some companies will honor our identity verification process, in which case they may not ask you to confirm your identity a second time.
+	</p>
+	
+	
+	<h2>3. Will CR be receiving my data?
+</h2>
+	<p>We have expressly asked companies to send (or otherwise make accessible) your data to you and you only. If a company accidentally sends your data (or a link to it) to Consumer Reports, we will delete it on first notice and respond to the company asking them to re-send the data (or link) to you directly. 
+
+	Our final report may comment on the kinds of data companies return in response to data access requests.
+	</p>
+	
+	
+	<h2>4. What if CR ends up receiving my data instead of me?</h2>
+	<p>Our research team will delete your data on first notice and ask the company to re-send the data directly to you instead. We don’t plan to view or use your data unless you personally send your data to our research team.</p>
+	
+	
+	<h2>5. If I don’t believe certain companies on your list have any of my data, why are you sending requests to them anyway?</h2>
+	<p>For experimental purposes. First, you may not have used a company’s services but they may have purchased data about you from third parties. If a company truly does not have any of your data, we want to see how long it takes them to confirm this and in what manner they choose to communicate this update.</p>
+	
+	
+	<h2>6. What is required of me in the next two months?</h2>
+	<p>Responses and data will help us understand how the data access process went for you and identify challenges and successes. We hope to use these findings to advocate to policymakers to improve consumer data rights and the methods to exercise them, to communicate with companies about how to respect consumer rights, and to develop services that help consumers exercise their rights.
+
+	You can help us gather this information in the following ways:
+	<ul>
+		<li>Confirm your identity with companies when they ask. Companies will likely reach out to you directly to confirm your identity. </li>
+		<li>Respond to three questionnaires sent by our team. These questionnaires will ask about your experience in the study, including what companies required of you to verify your identity; whether you received your data from companies; and whether the data was useful to you.</li>
+	</ul>
+	</p>
+	
+	
+	<h2>7. When should I expect to hear back from companies?</h2>
+	<p>By law, companies are required to fulfill your request within 45 business days of your identity confirmation. Please reach out to <a href="mailto:datarightsstudy@cr.org">datarightsstudy@cr.org</a> if you experience any unexpected delays.</p>
+	
+	
+	<h2>8. What is a witnessed Power of Attorney authorization? </h2>
+	<p>A small group of volunteers has been asked to grant Consumer Reports power of attorney to take data action on their behalf.  Under California law, a power of attorney must be either notarized or witnessed by two adults. We’re curious to see if and how companies react differently to this type of authorization.</p>
+	
+	
+	<h2>9. What's next at CR?</h2>
+    <p>Consumer Reports plans to launch a complete authorized agent service later in the coming months. You can sign up to receive announcements about this service, Permission Slip, <a href="http://permissionslipcr.com/">here</a>.</p>
+
+
+    <p>Thanks for helping Consumer Reports make data rights more meaningful! We couldn’t do this without you.</p>
+</div>
+
+{{>common-bottom}}

--- a/src/webapp/views/full.mustache
+++ b/src/webapp/views/full.mustache
@@ -5,7 +5,7 @@
 <div class="column">
     <p>Thanks for your interest in joining data rights research with Consumer Reports! Unfortunately, <b>we have reached capacity for this Data Access Agent study</b>. There’s a lot brewing here at the CR Digital Lab, so we’ll be in touch with our results and other research opportunities in the future.</p>
 
-    <p>If you have any questions, concerns, or would like to be added to a waitlist, please reach out to our team at <a href="mailto:datarightsstudy@cr.org">datarightsstudy@cr.org</a>. If you’re just curious about the research, you might enjoy our <a href="https://docs.google.com/document/d/1Fj2pNQOBONL-BTbnG4VFYLHaGfpaPHYcznZo5Jnll-A/edit">FAQ page</a>.</p>
+    <p>If you have any questions, concerns, or would like to be added to a waitlist, please reach out to our team at <a href="mailto:datarightsstudy@cr.org">datarightsstudy@cr.org</a>. If you’re just curious about the research, you might enjoy our <a href="/faq">FAQ page</a>.</p>
 
     <p>Consumer Reports plans to launch a complete authorized agent service later this year. You can sign up to receive announcements about this service, Permission Slip, <a href="http://permissionslipcr.com/">here</a>.</p>
 

--- a/src/webapp/views/full.mustache
+++ b/src/webapp/views/full.mustache
@@ -9,7 +9,7 @@
 
     <p>Consumer Reports plans to launch a complete authorized agent service later this year. You can sign up to receive announcements about this service, Permission Slip, <a href="http://permissionslipcr.com/">here</a>.</p>
 
-    <p>If you’re <i>already</i> enrolled in the study and want to review documents or opt out, click here or email us at <a href="mailto:datarightsstudy@cr.org">datarightsstudy@cr.org</a>.</p>
+    <p>If you’re <i>already</i> enrolled in the study and want to review documents or opt out, email us at <a href="mailto:datarightsstudy@cr.org">datarightsstudy@cr.org</a>.</p>
 
     <p>Thanks for helping Consumer Reports make data rights more meaningful! We couldn’t do this without you.</p>
 </div>

--- a/src/webapp/views/full.mustache
+++ b/src/webapp/views/full.mustache
@@ -1,0 +1,17 @@
+{{>common-top}}
+
+<h1>The Authorized Agent Study is Full</h1>
+
+<div class="column">
+    <p>Thanks for your interest in joining data rights research with Consumer Reports! Unfortunately, <b>we have reached capacity for this Data Access Agent study</b>. There’s a lot brewing here at the CR Digital Lab, so we’ll be in touch with our results and other research opportunities in the future.</p>
+
+    <p>If you have any questions, concerns, or would like to be added to a waitlist, please reach out to our team at <a href="mailto:datarightsstudy@cr.org">datarightsstudy@cr.org</a>. If you’re just curious about the research, you might enjoy our <a href="https://docs.google.com/document/d/1Fj2pNQOBONL-BTbnG4VFYLHaGfpaPHYcznZo5Jnll-A/edit">FAQ page</a>.</p>
+
+    <p>Consumer Reports plans to launch a complete authorized agent service later this year. You can sign up to receive announcements about this service, Permission Slip, <a href="http://permissionslipcr.com/">here</a>.</p>
+
+    <p>If you’re <i>already</i> enrolled in the study and want to review documents or opt out, click here or email us at <a href="mailto:datarightsstudy@cr.org">datarightsstudy@cr.org</a>.</p>
+
+    <p>Thanks for helping Consumer Reports make data rights more meaningful! We couldn’t do this without you.</p>
+</div>
+
+{{>common-bottom}}

--- a/src/webapp/views/index.mustache
+++ b/src/webapp/views/index.mustache
@@ -32,7 +32,7 @@
     <p>This Consumer Reports research study is designed to test how we might relieve you of some of the burden of making data requests by sending requests to companies for you. Just provide us with your contact information and give us your permission, then we'll get started.</p>
 
     <h2>How it works</h2>
-    <p> Read more on <a href="">the FAQ page</a>.</p>
+    <p> Read more on <a href="/faq">the FAQ page</a>.</p>
     <ol>
         <li>Sign up with your legal name, California address, email address, and mobile phone number.</li>
         <ul>

--- a/src/webapp/views/index.mustache
+++ b/src/webapp/views/index.mustache
@@ -32,7 +32,7 @@
     <p>This Consumer Reports research study is designed to test how we might relieve you of some of the burden of making data requests by sending requests to companies for you. Just provide us with your contact information and give us your permission, then we'll get started.</p>
 
     <h2>How it works</h2>
-
+    <p> Read more on <a href="">the FAQ page</a>.</p>
     <ol>
         <li>Sign up with your legal name, California address, email address, and mobile phone number.</li>
         <ul>

--- a/src/webapp/views/member/verify.mustache
+++ b/src/webapp/views/member/verify.mustache
@@ -28,7 +28,7 @@
 		</p>
 		<p>
 			<b>
-			After signing the authorization letter, you can choose to review or revoke your authorization by clicking <a id="status-link" href="#">here</a>. Feel free to bookmark this page so you can return to it at any time. 
+			After signing the authorization letter, you can choose to review or revoke your authorization by sending us a message at <a href="mailto:datarightsstudy@cr.org">datarightsstudy@cr.org</a>. 
 			</b>
 		</p>
 	</div>


### PR DESCRIPTION
Deploy heroku with this variable set in the application configuration to disable new signups but not
revocation+verification endpoints

Some of the text still needs to be edited/audited, nonpublic Google
Docs URL in it which I can also include easily enough when Maggie can
provide it.

not a big fan of the massive changes in the diff , but that'll happen when you have to add new branches to code... none of the logic is really changed except for the escape hatch.