### PR TITLE
disable mounting admin endpoint, okta.

### DIFF
--- a/src/webapp/index.js
+++ b/src/webapp/index.js
@@ -35,17 +35,17 @@ app.use(cookieSession({
     saveUninitialized: false
 }));
 
-const OktaWrapper = require('./okta');
-const okta = new OktaWrapper();
+// const OktaWrapper = require('./okta');
+// const okta = new OktaWrapper();
 
 // https://devforum.okta.com/t/oidc-middleware-issues-ensureauthenticated-doesnt-work-and-userinfo-isnt-set/659/4
 // "The OIDC router sets up all the middleware that is needed to
 // later use oidc.ensureAuthenticated(). We will update our
 // documentation to make this clearer."
-if (okta.oktaEnabled()) {
-    app.use(okta.middleware())
-    app.use(okta.oidc().router)
-}
+// if (okta.oktaEnabled()) {
+//     app.use(okta.middleware())
+//     app.use(okta.oidc().router)
+// }
 
 app.set('views', './views');
 app.set('view engine', 'mustache');
@@ -65,8 +65,7 @@ app.use(helmet({
         directives: cspDirectives,
     }
 }));
-const MakeAdminRouter = require('./admin');
-app.use('/admin', MakeAdminRouter(okta));
+
 app.use('/static', express.static('static'));
 app.use(express.urlencoded({ extended: true }));
 app.use(memberMountPoint, member);
@@ -104,19 +103,8 @@ const startFn = () => {
         debug(`Server initialized and listening on port ${PORT}.`);
     });
 };
-if (okta.oktaEnabled()) {
-    app.use(okta.middleware())
-    app.use(okta.oidc().router)
 
-    okta.oidc().on('ready', () => {
-        startFn();
-    });
-    okta.oidc().on('error', error => {
-        debug(`OIDC failed: ${error}`);
-    });
-} else {
-    startFn();
-}
+startFn();
 
 (async function remind() {
     const results = await remindUnverified(challengeResponseUrl);


### PR DESCRIPTION
This disables the okta middleware added in #4 and unmounts in the /admin router in expectation of public launch this week. We've had some problems getting the okta integration to work with the study's public URL, and @moates is comfortable working with SQL directly so we are going to disable this endpoint. 

It should be enough to revert this commit to re-enable Okta and the admin router, but the CloudFront domain which fronts the study needs to be more carefully configured than it is now to allow it to work, I think. Unfortunately the logging from the Node.js Okta middleware is virtually nonexistent, I think the majority of the information needed to debug this is in the Okta logs and AWS cloudfront configuration console...